### PR TITLE
 Update CloudFormation template to suppress cfn_nag warnings for S3 bucket logging configuration, ensuring compliance with nag scan requirements.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-</project>


### PR DESCRIPTION

*Description of changes:*
This commit updates the AWS CloudFormation template to address and suppress warnings from the cfn_nag tool related to the S3 bucket server access logging configuration. Specifically, it adds suppression rules within the metadata section of the S3 bucket resource definition.

This change is intended to explicitly pass the cfn_nag scan by documenting that the absence of access logging is a deliberate choice, based on the specific requirements of our deployment strategy, such as cost optimization or the particular use case of the bucket. This ensures our infrastructure as code remains compliant while clearly communicating our configurations' intent to security and audit teams.

*Test:*
```
  cfn_nag_scan --input-path  /Volumes/workplace/visbyTools/src/VisbyToolkit/templates/aws-b2bi-basic.template.yaml                                                

 ------------------------------------------------------------
 /Volumes/workplace/visbyTools/src/VisbyToolkit/templates/aws-b2bi-basic.template.yaml
 ------------------------------------------------------------
 Failures count: 0
 Warnings count: 0
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
